### PR TITLE
feat: add ref to gitlab_project_repository table

### DIFF
--- a/docs/tables/gitlab_project_repository.md
+++ b/docs/tables/gitlab_project_repository.md
@@ -17,6 +17,18 @@ where
   project_id = 123;  
 ```
 
+### List all files/folders for the development branch/tag in project repository
+
+```sql
+select
+  *
+from
+  gitlab_project_repository
+where
+  project_id = 123
+  AND ref = 'development';  
+```
+
 ### List all files for a project repository
 
 ```sql

--- a/gitlab/table_project_repository.go
+++ b/gitlab/table_project_repository.go
@@ -19,6 +19,11 @@ func tableProjectRepository() *plugin.Table {
 					Name:    "project_id",
 					Require: plugin.Required,
 				},
+				{
+					Name:      "ref",
+					Require:   plugin.Optional,
+					Operators: []string{"="},
+				},
 			},
 			Hydrate: listRepositoryTree,
 		},
@@ -42,6 +47,12 @@ func listRepositoryTree(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 			PerPage: 50,
 		},
 		Recursive: api.Bool(true),
+	}
+
+	if d.EqualsQualString("ref") != "" {
+		ref := api.String(d.EqualsQualString("ref"))
+		opt.Ref = ref
+		plugin.Logger(ctx).Debug("listRepositoryTree", "filter[ref]", *ref)
 	}
 
 	for {
@@ -99,6 +110,12 @@ func repoColumns() []*plugin.Column {
 			Name:        "mode",
 			Type:        proto.ColumnType_STRING,
 			Description: "The mode of the file or folder within the repository",
+		},
+		{
+			Name:        "ref",
+			Type:        proto.ColumnType_STRING,
+			Description: "The name of a repository branch or tag or, if not given, the default branch",
+			Transform:   transform.FromQual("ref"),
 		},
 		{
 			Name:        "project_id",


### PR DESCRIPTION
Related to https://github.com/theapsgroup/steampipe-plugin-gitlab/issues/70

Adding a `ref` value to filter results by. This is so you can query for the files in a non-default branch, but I've tried to configure it so it will use the default branch if none is specified.

Below are some example outputs and testing using this public Gitlab repo with id `22748841`: https://gitlab.com/renovate-bot/renovate-runner

## No `ref` set
Lists all the files and folders on the default branch. The `ref` column gets added but set as `<null>`
```
> SELECT * FROM gitlab_project_repository WHERE project_id = 22748841 ORDER BY name
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+--------+------------+------------------------------+
| id                                       | name                                    | type | path                                              | mode   | ref    | project_id | _ctx                         |
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+--------+------------+------------------------------+
| bb0bbc752430295b71c67a0e30be668a674f5fdc | .editorconfig                           | blob | .editorconfig                                     | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 67b46199b05ba79a910ffdcf161e5780b83c9ca4 | .gitignore                              | blob | .gitignore                                        | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| adb192dbc57df1fba6cae00ce0ef1d3b0e58e5fe | .gitlab                                 | tree | .gitlab                                           | 040000 | <null> | 22748841   | {"connection_name":"gitlab"} |
| e9f21b9fa39d6dbf68b79647a99e1d0dba7b968e | .gitlab-ci.yml                          | blob | .gitlab-ci.yml                                    | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| e6ce24833fe72f1ef9d846f9c3b956fe08d8a2da | .gitpod.yml                             | blob | .gitpod.yml                                       | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 1dab4ed4c30209bd7fbead04a2965c6b022db49f | .npmrc                                  | blob | .npmrc                                            | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| c1a6f66713166020e90a73182ca967212bd18ea3 | .prettierrc                             | blob | .prettierrc                                       | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| e6ea0f8988db162879edaa15e9ba93e86773fbfb | .releaserc.json                         | blob | .releaserc.json                                   | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| dc67690a6e070312899c8ccd621db993b6c07534 | .vscode                                 | tree | .vscode                                           | 040000 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 7c7f85e5bb6420b471f90634c673071d95c2aa63 | LICENSE                                 | blob | LICENSE                                           | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 9e03937d8fa8f0e268a5331ac74b1d76e2d56bed | README.md                               | blob | README.md                                         | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 2229db064bcb6f4fe7945b8fb2b7a5df76b71a9c | default.json                            | blob | default.json                                      | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 4a609681cf1167de43520d88c834e5995c08c382 | package-lock.json                       | blob | package-lock.json                                 | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 28907cfa017a16e47082785d4e59cd8ac14d8cc4 | package.json                            | blob | package.json                                      | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| a8453e2887a354c5bc1ede9ae14523cb75a4cd30 | renovate-config-validator.gitlab-ci.yml | blob | templates/renovate-config-validator.gitlab-ci.yml | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 59e77da6518d0a78acc1776aacc0e3fb532a0089 | renovate.gitlab-ci.yml                  | blob | templates/renovate.gitlab-ci.yml                  | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 91e726d3245f59932d73a875c482642e5724455f | renovate.json                           | blob | .gitlab/renovate.json                             | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 9bf4d12b52fa6b7b50e0d256dc20838b849880e1 | settings.json                           | blob | .vscode/settings.json                             | 100644 | <null> | 22748841   | {"connection_name":"gitlab"} |
| 96ba41f0f902c42195d33c06b626fa09fc739c1c | templates                               | tree | templates                                         | 040000 | <null> | 22748841   | {"connection_name":"gitlab"} |
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+--------+------------+------------------------------+
```

## Ref set to `main`
Since `main` is the default branch this has the same output as above, except the `ref` column is filled in
```
> SELECT * FROM gitlab_project_repository WHERE project_id = 22748841 AND ref = 'main' ORDER BY name
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+------+------------+------------------------------+
| id                                       | name                                    | type | path                                              | mode   | ref  | project_id | _ctx                         |
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+------+------------+------------------------------+
| bb0bbc752430295b71c67a0e30be668a674f5fdc | .editorconfig                           | blob | .editorconfig                                     | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 67b46199b05ba79a910ffdcf161e5780b83c9ca4 | .gitignore                              | blob | .gitignore                                        | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| adb192dbc57df1fba6cae00ce0ef1d3b0e58e5fe | .gitlab                                 | tree | .gitlab                                           | 040000 | main | 22748841   | {"connection_name":"gitlab"} |
| e9f21b9fa39d6dbf68b79647a99e1d0dba7b968e | .gitlab-ci.yml                          | blob | .gitlab-ci.yml                                    | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| e6ce24833fe72f1ef9d846f9c3b956fe08d8a2da | .gitpod.yml                             | blob | .gitpod.yml                                       | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 1dab4ed4c30209bd7fbead04a2965c6b022db49f | .npmrc                                  | blob | .npmrc                                            | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| c1a6f66713166020e90a73182ca967212bd18ea3 | .prettierrc                             | blob | .prettierrc                                       | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| e6ea0f8988db162879edaa15e9ba93e86773fbfb | .releaserc.json                         | blob | .releaserc.json                                   | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| dc67690a6e070312899c8ccd621db993b6c07534 | .vscode                                 | tree | .vscode                                           | 040000 | main | 22748841   | {"connection_name":"gitlab"} |
| 7c7f85e5bb6420b471f90634c673071d95c2aa63 | LICENSE                                 | blob | LICENSE                                           | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 9e03937d8fa8f0e268a5331ac74b1d76e2d56bed | README.md                               | blob | README.md                                         | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 2229db064bcb6f4fe7945b8fb2b7a5df76b71a9c | default.json                            | blob | default.json                                      | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 4a609681cf1167de43520d88c834e5995c08c382 | package-lock.json                       | blob | package-lock.json                                 | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 28907cfa017a16e47082785d4e59cd8ac14d8cc4 | package.json                            | blob | package.json                                      | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| a8453e2887a354c5bc1ede9ae14523cb75a4cd30 | renovate-config-validator.gitlab-ci.yml | blob | templates/renovate-config-validator.gitlab-ci.yml | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 59e77da6518d0a78acc1776aacc0e3fb532a0089 | renovate.gitlab-ci.yml                  | blob | templates/renovate.gitlab-ci.yml                  | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 91e726d3245f59932d73a875c482642e5724455f | renovate.json                           | blob | .gitlab/renovate.json                             | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 9bf4d12b52fa6b7b50e0d256dc20838b849880e1 | settings.json                           | blob | .vscode/settings.json                             | 100644 | main | 22748841   | {"connection_name":"gitlab"} |
| 96ba41f0f902c42195d33c06b626fa09fc739c1c | templates                               | tree | templates                                         | 040000 | main | 22748841   | {"connection_name":"gitlab"} |
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+------+------------+------------------------------+
```

## Ref set to `ci/docker-proxy`, a non-default branch
This grabs the files and folders from the `ci/docker-proxy` branch, which has different files than the `main` branch.
```
> SELECT * FROM gitlab_project_repository WHERE project_id = 22748841 AND ref = 'ci/docker-proxy' ORDER BY name
+------------------------------------------+-----------------------------+------+---------------------------------------+--------+-----------------+------------+------------------------------+
| id                                       | name                        | type | path                                  | mode   | ref             | project_id | _ctx                         |
+------------------------------------------+-----------------------------+------+---------------------------------------+--------+-----------------+------------+------------------------------+
| bb0bbc752430295b71c67a0e30be668a674f5fdc | .editorconfig               | blob | .editorconfig                         | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 31022dafb2428d88fee81312d918f536de3d8d79 | .gitignore                  | blob | .gitignore                            | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| d77085b927d1507d8f7654b6910de8ae8704d4ac | .gitlab-ci.yml              | blob | .gitlab-ci.yml                        | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| c1a6f66713166020e90a73182ca967212bd18ea3 | .prettierrc                 | blob | .prettierrc                           | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 890e5c89600eab4659556684a4db7cf8e522a43f | .releaserc.json             | blob | .releaserc.json                       | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 7c7f85e5bb6420b471f90634c673071d95c2aa63 | LICENSE                     | blob | LICENSE                               | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| abe50ea1cce82d4c41b37e5e346d72ed2430e27a | README.md                   | blob | README.md                             | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 2c856122af425d8831905d835581b93b8b10fe4c | _common.gitlab-ci.yml       | blob | templates/_common.gitlab-ci.yml       | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 863a6704ccbabc6300b7d5c7bf17d7dc7ba1d5af | package-lock.json           | blob | package-lock.json                     | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 5290b6e29289e0c35e3ab3456ae4a98bed8c9db6 | package.json                | blob | package.json                          | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 7c06c40277fedb775374c6c23fe7e9b62b64be32 | renovate-dind.gitlab-ci.yml | blob | templates/renovate-dind.gitlab-ci.yml | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| d69bba37ae75303ae901c83c9679824d5cb6750d | renovate.gitlab-ci.yml      | blob | templates/renovate.gitlab-ci.yml      | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| 7374cb51db801e8747447e25e709f7e569363fea | renovate.json               | blob | renovate.json                         | 100644 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
| f8c666d31528c7efc8e026b475b3ebd53348ac6a | templates                   | tree | templates                             | 040000 | ci/docker-proxy | 22748841   | {"connection_name":"gitlab"} |
+------------------------------------------+-----------------------------+------+---------------------------------------+--------+-----------------+------------+------------------------------+
```

## Ref set to `v17.222.5`, a tag
This grabs the files/folders for the `v17.222.5` tag, an older tag I chose at random. The `id` field for some of the files/folders is different than the ones from `main`, like the `package.json` file, indicating that those files have changed from the current version. You could use this to get a list of the files that have changed between different branches/tags
```
> SELECT * FROM gitlab_project_repository WHERE project_id = 22748841 AND ref = 'v17.222.5' ORDER BY name
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+-----------+------------+------------------------------+
| id                                       | name                                    | type | path                                              | mode   | ref       | project_id | _ctx                         |
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+-----------+------------+------------------------------+
| bb0bbc752430295b71c67a0e30be668a674f5fdc | .editorconfig                           | blob | .editorconfig                                     | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 67b46199b05ba79a910ffdcf161e5780b83c9ca4 | .gitignore                              | blob | .gitignore                                        | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| adb192dbc57df1fba6cae00ce0ef1d3b0e58e5fe | .gitlab                                 | tree | .gitlab                                           | 040000 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 4505a9e34f9dd2b50983d171eb2cc4410e86a3bb | .gitlab-ci.yml                          | blob | .gitlab-ci.yml                                    | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| e6ce24833fe72f1ef9d846f9c3b956fe08d8a2da | .gitpod.yml                             | blob | .gitpod.yml                                       | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 1dab4ed4c30209bd7fbead04a2965c6b022db49f | .npmrc                                  | blob | .npmrc                                            | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| c1a6f66713166020e90a73182ca967212bd18ea3 | .prettierrc                             | blob | .prettierrc                                       | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| e6ea0f8988db162879edaa15e9ba93e86773fbfb | .releaserc.json                         | blob | .releaserc.json                                   | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| dc67690a6e070312899c8ccd621db993b6c07534 | .vscode                                 | tree | .vscode                                           | 040000 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 7c7f85e5bb6420b471f90634c673071d95c2aa63 | LICENSE                                 | blob | LICENSE                                           | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 2e137dfa8a09ab4f498604b12bab128d1981aba1 | README.md                               | blob | README.md                                         | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 2229db064bcb6f4fe7945b8fb2b7a5df76b71a9c | default.json                            | blob | default.json                                      | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 0a306b378c56edfc5cfab111fa4452b33273c31f | package-lock.json                       | blob | package-lock.json                                 | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 77dd2908a0e0bdfcf2d62ee0e19431c09e021fd9 | package.json                            | blob | package.json                                      | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 7d38799e5be8ac95d4b2f8155beaf576cdf5a494 | renovate-config-validator.gitlab-ci.yml | blob | templates/renovate-config-validator.gitlab-ci.yml | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| b7deac90ce574c89650ebdc3e799209da5388285 | renovate.gitlab-ci.yml                  | blob | templates/renovate.gitlab-ci.yml                  | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 91e726d3245f59932d73a875c482642e5724455f | renovate.json                           | blob | .gitlab/renovate.json                             | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| 9bf4d12b52fa6b7b50e0d256dc20838b849880e1 | settings.json                           | blob | .vscode/settings.json                             | 100644 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
| b31e739fcbd39b5d3aca5dd3694ebb1aa5dab040 | templates                               | tree | templates                                         | 040000 | v17.222.5 | 22748841   | {"connection_name":"gitlab"} |
+------------------------------------------+-----------------------------------------+------+---------------------------------------------------+--------+-----------+------------+------------------------------+
```

## Get files that have changed
This query could probably be cleaned up but this is just getting the files that have a different `id` value between the default branch and the `v17.222.5` tag, using an `EXCEPT`
```
> SELECT name, type, path, id FROM gitlab_project_repository WHERE project_id = 22748841 EXCEPT SELECT name, type, path, id FROM gitlab_project_repository WHERE project_id = 22748841 AND ref = 'v17.222.5'
+-----------------------------------------+------+---------------------------------------------------+------------------------------------------+
| name                                    | type | path                                              | id                                       |
+-----------------------------------------+------+---------------------------------------------------+------------------------------------------+
| .gitlab-ci.yml                          | blob | .gitlab-ci.yml                                    | e9f21b9fa39d6dbf68b79647a99e1d0dba7b968e |
| README.md                               | blob | README.md                                         | 9e03937d8fa8f0e268a5331ac74b1d76e2d56bed |
| package-lock.json                       | blob | package-lock.json                                 | 4a609681cf1167de43520d88c834e5995c08c382 |
| package.json                            | blob | package.json                                      | 28907cfa017a16e47082785d4e59cd8ac14d8cc4 |
| renovate-config-validator.gitlab-ci.yml | blob | templates/renovate-config-validator.gitlab-ci.yml | a8453e2887a354c5bc1ede9ae14523cb75a4cd30 |
| renovate.gitlab-ci.yml                  | blob | templates/renovate.gitlab-ci.yml                  | 59e77da6518d0a78acc1776aacc0e3fb532a0089 |
| templates                               | tree | templates                                         | 96ba41f0f902c42195d33c06b626fa09fc739c1c |
+-----------------------------------------+------+---------------------------------------------------+------------------------------------------+

```